### PR TITLE
Add Rename and Sync capabilities for atomic writes

### DIFF
--- a/fs.go
+++ b/fs.go
@@ -17,6 +17,14 @@ type WriterFile interface {
 	io.Writer
 }
 
+// SyncWriterFile is a WriterFile that can flush its contents to stable storage.
+// Filesystems backed by the OS should implement Sync via (*os.File).Sync.
+// In-memory filesystems may implement Sync as a no-op.
+type SyncWriterFile interface {
+	WriterFile
+	Sync() error
+}
+
 // WriteFileFS is the interface implemented by a filesystem that provides an
 // optimized implementation of MkdirAll, CreateFile, WriteFile.
 type WriteFileFS interface {
@@ -77,6 +85,24 @@ func RemoveAll(fsys fs.FS, path string) error {
 		return fsys.RemoveAll(path)
 	}
 	return &fs.PathError{Op: "RemoveAll", Path: path, Err: ErrNotImplemented}
+}
+
+// RenameFS is the interface implemented by a filesystem that supports
+// renaming files. On POSIX-backed filesystems, Rename is atomic when oldpath
+// and newpath are on the same filesystem, which is the primitive used to
+// commit atomic writes.
+type RenameFS interface {
+	fs.FS
+	Rename(oldpath, newpath string) error
+}
+
+// Rename renames oldpath to newpath. If the filesystem implements RenameFS
+// calls fsys.Rename otherwise returns a PathError.
+func Rename(fsys fs.FS, oldpath, newpath string) error {
+	if fsys, ok := fsys.(RenameFS); ok {
+		return fsys.Rename(oldpath, newpath)
+	}
+	return &fs.PathError{Op: "Rename", Path: oldpath, Err: ErrNotImplemented}
 }
 
 // CopyFS walks the specified root directory on src and copies directories and

--- a/fs_test.go
+++ b/fs_test.go
@@ -204,6 +204,35 @@ func TestRemoveAll_ErrNotImplemented(t *testing.T) {
 	}
 }
 
+func TestRename(t *testing.T) {
+	var gotOld, gotNew string
+	fsys := &FSDelegator{
+		RenameFunc: func(oldpath, newpath string) error {
+			gotOld, gotNew = oldpath, newpath
+			return nil
+		},
+	}
+	if err := Rename(fsys, "a", "b"); err != nil {
+		t.Fatal(err)
+	}
+	if gotOld != "a" || gotNew != "b" {
+		t.Errorf("unexpected %s -> %s", gotOld, gotNew)
+	}
+}
+
+func TestRename_ErrNotImplemented(t *testing.T) {
+	fsys := &OpenFSDelegator{}
+	wantErr := &fs.PathError{Op: "Rename", Path: "a", Err: ErrNotImplemented}
+	err := Rename(fsys, "a", "b")
+	if err == nil {
+		t.Fatal("no error")
+	}
+	gotErr, ok := err.(*fs.PathError)
+	if !ok || gotErr.Error() != wantErr.Error() {
+		t.Errorf("unexpected %v; want %v", err, wantErr)
+	}
+}
+
 func TestCopyFS(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "test")
 	if err != nil {

--- a/fsdelegator.go
+++ b/fsdelegator.go
@@ -36,6 +36,7 @@ type FSDelegator struct {
 	WriteFileFunc  func(name string, p []byte, mode fs.FileMode) (int, error)
 	RemoveFileFunc func(name string) error
 	RemoveAllFunc  func(path string) error
+	RenameFunc     func(oldpath, newpath string) error
 }
 
 var (
@@ -47,6 +48,7 @@ var (
 	_ fs.SubFS      = (*FSDelegator)(nil)
 	_ WriteFileFS   = (*FSDelegator)(nil)
 	_ RemoveFileFS  = (*FSDelegator)(nil)
+	_ RenameFS      = (*FSDelegator)(nil)
 )
 
 // Open calls OpenFunc(name).
@@ -130,6 +132,14 @@ func (d *FSDelegator) RemoveFile(name string) error {
 	return d.RemoveFileFunc(name)
 }
 
+// Rename calls RenameFunc(oldpath, newpath).
+func (d *FSDelegator) Rename(oldpath, newpath string) error {
+	if d.RenameFunc == nil {
+		return &fs.PathError{Op: "Rename", Path: oldpath, Err: ErrNotImplemented}
+	}
+	return d.RenameFunc(oldpath, newpath)
+}
+
 // RemoveAll calls RemoveAllFunc(name).
 func (d *FSDelegator) RemoveAll(path string) error {
 	if d.RemoveAllFunc == nil {
@@ -187,6 +197,9 @@ func DelegateFS(fsys fs.FS) *FSDelegator {
 		d.RemoveFileFunc = casted.RemoveFile
 		d.RemoveAllFunc = casted.RemoveAll
 	}
+	if casted, ok := fsys.(RenameFS); ok {
+		d.RenameFunc = casted.Rename
+	}
 	return d
 }
 
@@ -197,12 +210,14 @@ type FileDelegator struct {
 	CloseFunc   func() error
 	ReadDirFunc func(n int) ([]fs.DirEntry, error)
 	WriteFunc   func(p []byte) (int, error)
+	SyncFunc    func() error
 }
 
 var (
 	_ fs.File        = (*FileDelegator)(nil)
 	_ fs.ReadDirFile = (*FileDelegator)(nil)
 	_ WriterFile     = (*FileDelegator)(nil)
+	_ SyncWriterFile = (*FileDelegator)(nil)
 )
 
 // Stat calls StatFunc().
@@ -246,6 +261,15 @@ func (f *FileDelegator) Write(p []byte) (int, error) {
 	return f.WriteFunc(p)
 }
 
+// Sync calls SyncFunc().
+func (f *FileDelegator) Sync() error {
+	if f.SyncFunc == nil {
+		// NOTE: return no error so non-syncing files behave as a no-op.
+		return nil
+	}
+	return f.SyncFunc()
+}
+
 // DelegateFile returns a FileDelegator delegates the functions of the specified file.
 func DelegateFile(f fs.File) *FileDelegator {
 	d := &FileDelegator{
@@ -258,6 +282,9 @@ func DelegateFile(f fs.File) *FileDelegator {
 	}
 	if f, ok := f.(WriterFile); ok {
 		d.WriteFunc = f.Write
+	}
+	if f, ok := f.(SyncWriterFile); ok {
+		d.SyncFunc = f.Sync
 	}
 	return d
 }

--- a/memfs/memfs.go
+++ b/memfs/memfs.go
@@ -30,6 +30,7 @@ var (
 	_ fs.SubFS         = (*MemFS)(nil)
 	_ wfs.WriteFileFS  = (*MemFS)(nil)
 	_ wfs.RemoveFileFS = (*MemFS)(nil)
+	_ wfs.RenameFS     = (*MemFS)(nil)
 )
 
 // New returns a new MemFS.
@@ -246,6 +247,43 @@ func (fsys *MemFS) WriteFile(name string, p []byte, mode fs.FileMode) (int, erro
 	return copy(v.data, p), nil
 }
 
+// Rename renames oldpath to newpath. The move happens atomically under the
+// filesystem mutex. Rename currently supports files only; renaming a directory
+// returns a PathError. If newpath already exists as a file it is replaced.
+func (fsys *MemFS) Rename(oldpath, newpath string) error {
+	fsys.mutex.Lock()
+	defer fsys.mutex.Unlock()
+
+	if !fs.ValidPath(oldpath) {
+		return &fs.PathError{Op: "Rename", Path: oldpath, Err: fs.ErrInvalid}
+	}
+	if !fs.ValidPath(newpath) {
+		return &fs.PathError{Op: "Rename", Path: newpath, Err: fs.ErrInvalid}
+	}
+
+	oldKey := fsys.key(oldpath)
+	v := fsys.store.get(oldKey)
+	if v == nil {
+		return &fs.PathError{Op: "Rename", Path: oldpath, Err: fs.ErrNotExist}
+	}
+	if v.isDir {
+		return &fs.PathError{Op: "Rename", Path: oldpath, Err: fs.ErrInvalid}
+	}
+
+	if err := fsys.mkdirAll(path.Dir(newpath), v.mode); err != nil {
+		return err
+	}
+	newKey := fsys.key(newpath)
+	if existing := fsys.store.get(newKey); existing != nil && existing.isDir {
+		return &fs.PathError{Op: "Rename", Path: newpath, Err: fs.ErrInvalid}
+	}
+
+	fsys.store.remove(oldKey)
+	v.name = newKey
+	fsys.store.put(newKey, v)
+	return nil
+}
+
 // RemoveFile removes the specified named file.
 func (fsys *MemFS) RemoveFile(name string) error {
 	fsys.mutex.Lock()
@@ -286,9 +324,10 @@ type MemFile struct {
 }
 
 var (
-	_ fs.File        = (*MemFile)(nil)
-	_ fs.ReadDirFile = (*MemFile)(nil)
-	_ wfs.WriterFile = (*MemFile)(nil)
+	_ fs.File            = (*MemFile)(nil)
+	_ fs.ReadDirFile     = (*MemFile)(nil)
+	_ wfs.WriterFile     = (*MemFile)(nil)
+	_ wfs.SyncWriterFile = (*MemFile)(nil)
 )
 
 // Read reads bytes from this file.
@@ -348,4 +387,11 @@ func (f *MemFile) ReadDir(n int) ([]fs.DirEntry, error) {
 func (f *MemFile) Write(p []byte) (int, error) {
 	f.wrote = true
 	return f.buf.Write(p)
+}
+
+// Sync is a no-op for in-memory files. It exists to satisfy
+// wfs.SyncWriterFile so that callers writing for crash safety on osfs can
+// share the same code path on memfs.
+func (f *MemFile) Sync() error {
+	return nil
 }

--- a/memfs/memfs_test.go
+++ b/memfs/memfs_test.go
@@ -41,6 +41,33 @@ func TestWriteFileFS(t *testing.T) {
 	}
 }
 
+func TestRenameFS(t *testing.T) {
+	fsys := New()
+	tmpdir := "tmpdir"
+	if err := fsys.MkdirAll(tmpdir, fs.ModePerm); err != nil {
+		t.Fatal(err)
+	}
+	if err := wfstest.TestRenameFS(fsys, tmpdir); err != nil {
+		t.Errorf(`Error wfs/wfstest: %+v`, err)
+	}
+}
+
+func TestMemFile_Sync(t *testing.T) {
+	fsys := New()
+	f, err := fsys.CreateFile("sync.txt", fs.ModePerm)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	sf, ok := f.(wfs.SyncWriterFile)
+	if !ok {
+		t.Fatalf("memfs CreateFile result does not implement SyncWriterFile")
+	}
+	if err := sf.Sync(); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+}
+
 func TestCreateFile(t *testing.T) {
 	testCases := []struct {
 		name   string

--- a/osfs/osfs.go
+++ b/osfs/osfs.go
@@ -39,6 +39,10 @@ var osRemoveFunc = func(name string) error {
 	return os.Remove(name)
 }
 
+var osRenameFunc = func(oldpath, newpath string) error {
+	return os.Rename(oldpath, newpath)
+}
+
 var osRemoveAllFunc = func(path string) error {
 	return os.RemoveAll(path)
 }
@@ -58,6 +62,7 @@ var (
 	_ fs.SubFS         = (*OSFS)(nil)
 	_ wfs.WriteFileFS  = (*OSFS)(nil)
 	_ wfs.RemoveFileFS = (*OSFS)(nil)
+	_ wfs.RenameFS     = (*OSFS)(nil)
 )
 
 // NewOSFS returns a filesystem for the tree of files rooted at the directory dir.
@@ -145,6 +150,18 @@ func (fsys *OSFS) RemoveFile(name string) error {
 		return &fs.PathError{Op: "Remove", Path: name, Err: fs.ErrInvalid}
 	}
 	return osRemoveFunc(filepath.Join(fsys.Dir, name))
+}
+
+// Rename renames oldpath to newpath using os.Rename. On POSIX-backed
+// filesystems this is atomic when both paths are on the same filesystem.
+func (fsys *OSFS) Rename(oldpath, newpath string) error {
+	if isInvalidPath(oldpath) {
+		return &fs.PathError{Op: "Rename", Path: oldpath, Err: fs.ErrInvalid}
+	}
+	if isInvalidPath(newpath) {
+		return &fs.PathError{Op: "Rename", Path: newpath, Err: fs.ErrInvalid}
+	}
+	return osRenameFunc(filepath.Join(fsys.Dir, oldpath), filepath.Join(fsys.Dir, newpath))
 }
 
 // RemoveAll removes path and any children it contains.

--- a/osfs/osfs_test.go
+++ b/osfs/osfs_test.go
@@ -33,6 +33,44 @@ func TestWriteFileFS(t *testing.T) {
 	}
 }
 
+func TestRenameFS(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	fsys := New(filepath.Dir(tmpDir))
+	if err := wfstest.TestRenameFS(fsys, filepath.Base(tmpDir)); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSyncWriterFile(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	fsys := New(tmpDir)
+	f, err := fsys.CreateFile("sync.txt", fs.ModePerm)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	if _, err := f.Write([]byte("data")); err != nil {
+		t.Fatal(err)
+	}
+	sf, ok := f.(wfs.SyncWriterFile)
+	if !ok {
+		t.Fatalf("osfs CreateFile result does not implement SyncWriterFile")
+	}
+	if err := sf.Sync(); err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+}
+
 func TestMkdirAll(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "test")
 	if err != nil {

--- a/wfstest/wfstest.go
+++ b/wfstest/wfstest.go
@@ -74,6 +74,59 @@ func TestWriteFileFS(fsys fs.FS, tmpDir string) error {
 	return nil
 }
 
+// TestRenameFS tests a wfs.RenameFS implementation. It assumes the filesystem
+// also implements wfs.WriteFileFS so it can stage source files. tmpDir is a
+// directory the test may freely create and destroy entries under.
+func TestRenameFS(fsys fs.FS, tmpDir string) error {
+	src := tmpDir + "/rename_src.txt"
+	dst := tmpDir + "/rename_dst.txt"
+	data := []byte("payload")
+
+	if _, err := wfs.WriteFile(fsys, src, data, fs.ModePerm); err != nil {
+		return fmt.Errorf("WriteFile %s: %v", src, err)
+	}
+	if err := wfs.Rename(fsys, src, dst); err != nil {
+		return fmt.Errorf("Rename %s -> %s: %v", src, dst, err)
+	}
+	got, err := wfs.ReadFile(fsys, dst)
+	if err != nil {
+		return fmt.Errorf("ReadFile %s after rename: %v", dst, err)
+	}
+	if string(got) != string(data) {
+		return fmt.Errorf("Rename: content got %q; want %q", got, data)
+	}
+	if _, err := fsys.Open(src); err == nil {
+		return fmt.Errorf("Rename: source %s still exists", src)
+	}
+
+	// Rename over an existing file should replace it.
+	other := tmpDir + "/rename_other.txt"
+	other2 := []byte("other-payload")
+	if _, err := wfs.WriteFile(fsys, other, other2, fs.ModePerm); err != nil {
+		return fmt.Errorf("WriteFile %s: %v", other, err)
+	}
+	if err := wfs.Rename(fsys, other, dst); err != nil {
+		return fmt.Errorf("Rename overwrite %s -> %s: %v", other, dst, err)
+	}
+	got, err = wfs.ReadFile(fsys, dst)
+	if err != nil {
+		return fmt.Errorf("ReadFile %s after overwrite: %v", dst, err)
+	}
+	if string(got) != string(other2) {
+		return fmt.Errorf("Rename overwrite: content got %q; want %q", got, other2)
+	}
+
+	// Rename of a missing file should fail.
+	if err := wfs.Rename(fsys, tmpDir+"/does_not_exist.txt", tmpDir+"/whatever.txt"); err == nil {
+		return fmt.Errorf("Rename missing source: expected error, got nil")
+	}
+
+	if err := wfs.RemoveFile(fsys, dst); err != nil {
+		return fmt.Errorf("RemoveFile %s: %v", dst, err)
+	}
+	return nil
+}
+
 func checkFileWrite(fsys fs.FS, f wfs.WriterFile, name string) error {
 	ps := [][]byte{[]byte("hello"), []byte(",world")}
 	data := append(ps[0], ps[1]...)


### PR DESCRIPTION
Introduces RenameFS and SyncWriterFile capability interfaces so callers can implement crash-safe atomic writes (temp file + sync + rename) through the wfs abstraction without bypassing it. osfs wraps os.Rename and (*os.File).Sync; memfs moves entries under its mutex and treats Sync as a no-op so the same caller code works on both backends.

Closes #5