### PR TITLE
memfs: Share mutex between parent and Sub-derived filesystems

### DIFF
--- a/memfs/memfs.go
+++ b/memfs/memfs.go
@@ -15,8 +15,12 @@ import (
 
 // MemFS represents an in-memory filesystem.
 // MemFS keeps fs.FileMode but that permission is not checked.
+//
+// MemFS values returned from Sub share both the underlying store and the
+// mutex with their parent so concurrent access through a parent and any of
+// its sub-filesystems is serialized through a single lock.
 type MemFS struct {
-	mutex sync.Mutex
+	mutex *sync.Mutex
 	dir   string
 	store *store
 }
@@ -36,6 +40,7 @@ var (
 // New returns a new MemFS.
 func New() *MemFS {
 	return &MemFS{
+		mutex: &sync.Mutex{},
 		dir:   "/",
 		store: newStore(),
 	}
@@ -205,6 +210,7 @@ func (fsys *MemFS) Sub(dir string) (fs.FS, error) {
 		return nil, &fs.PathError{Op: "Sub", Path: dir, Err: fs.ErrInvalid}
 	}
 	return &MemFS{
+		mutex: fsys.mutex,
 		dir:   path.Join(fsys.dir, dir),
 		store: fsys.store,
 	}, nil

--- a/memfs/memfs_test.go
+++ b/memfs/memfs_test.go
@@ -52,6 +52,38 @@ func TestRenameFS(t *testing.T) {
 	}
 }
 
+func TestSubSharesMutex(t *testing.T) {
+	fsys := New()
+	if err := fsys.MkdirAll("sub", fs.ModePerm); err != nil {
+		t.Fatal(err)
+	}
+	subFS, err := fsys.Sub("sub")
+	if err != nil {
+		t.Fatal(err)
+	}
+	sub, ok := subFS.(*MemFS)
+	if !ok {
+		t.Fatalf("Sub returned %T; want *MemFS", subFS)
+	}
+	if sub.mutex != fsys.mutex {
+		t.Errorf("Sub MemFS does not share mutex with parent")
+	}
+
+	// Smoke test concurrent access through parent and sub. With a shared
+	// mutex this is race-free; -race will catch a regression.
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < 100; i++ {
+			_, _ = wfs.WriteFile(fsys, "sub/a.txt", []byte("a"), fs.ModePerm)
+		}
+		close(done)
+	}()
+	for i := 0; i < 100; i++ {
+		_, _ = wfs.WriteFile(sub, "b.txt", []byte("b"), fs.ModePerm)
+	}
+	<-done
+}
+
 func TestMemFile_Sync(t *testing.T) {
 	fsys := New()
 	f, err := fsys.CreateFile("sync.txt", fs.ModePerm)

--- a/memfs/store.go
+++ b/memfs/store.go
@@ -60,7 +60,13 @@ func (v *value) Info() (fs.FileInfo, error) {
 
 // Store represents an in-memory key value store.
 // store.keys is always sorted.
-// All functions of the store are not thread safety.
+//
+// None of store's methods are safe for concurrent use. Callers MUST hold
+// an external *sync.Mutex for the entire duration of any store operation,
+// including operations that combine multiple store calls (for example a
+// get followed by a put). MemFS is the only intended user of store and
+// satisfies this contract by taking fsys.mutex at the top of every public
+// MemFS method that touches the store.
 type store struct {
 	keys   []string
 	values map[string]*value


### PR DESCRIPTION
MemFS.Sub previously returned a new MemFS with a fresh sync.Mutex while sharing the underlying store. 
Concurrent access through a parent and any of its sub-filesystems therefore raced because the two locks protected nothing relative to each other. 
Hold the mutex by pointer and have Sub copy the parent pointer so all views of the same store serialize through a single lock.