### PR TITLE
chore: lower minimum Go to 1.24 and add CI matrix

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: ['1.24', '1.25', 'stable']
+        go-version: ['1.24', 'stable']
     steps:
       -
         name: Checkout

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -41,12 +41,17 @@ jobs:
           go mod tidy
           go test -v ./...
       -
+        # staticcheck v0.7.0 requires Go >= 1.25, so only run linters on
+        # the latest toolchain in the matrix. Tests still cover all
+        # supported Go versions.
         name: Run staticcheck
+        if: matrix.go-version == 'stable'
         run: |
           go install honnef.co/go/tools/cmd/staticcheck@v0.7.0
           staticcheck ./...
       -
         name: Run gosec
+        if: matrix.go-version == 'stable'
         run: |
           go install github.com/securego/gosec/v2/cmd/gosec@v2.24.7
           gosec ./...

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,6 +12,10 @@ on:
 jobs:
   tests:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        go-version: ['1.24', '1.25', 'stable']
     steps:
       -
         name: Checkout
@@ -22,7 +26,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version-file: go.mod
+          go-version: ${{ matrix.go-version }}
       -
         name: Cache Go modules
         uses: actions/cache@v5

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,7 +10,7 @@ on:
   workflow_call:
 
 jobs:
-  tests:
+  test:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -55,3 +55,18 @@ jobs:
         run: |
           go install github.com/securego/gosec/v2/cmd/gosec@v2.24.7
           gosec ./...
+
+  # Aggregator job kept under the stable name "tests" so the branch
+  # protection required check does not need to be reconfigured every
+  # time the matrix changes.
+  tests:
+    runs-on: ubuntu-latest
+    needs: test
+    if: always()
+    steps:
+      - name: Check matrix results
+        run: |
+          if [ "${{ needs.test.result }}" != "success" ]; then
+            echo "matrix job failed: ${{ needs.test.result }}"
+            exit 1
+          fi

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/mojatter/wfs
 
-go 1.26
+go 1.24


### PR DESCRIPTION
## Summary
- Drop \`go.mod\`'s go directive from 1.26 to 1.24 so projects on older toolchains can consume wfs.
- Add a Go version matrix (\`1.24\`,  \`stable\`) to \`tests.yaml\` so regressions against the lowest supported version are caught in CI.

Part of the v0.5.0 release prep.

## Test plan
- [x] CI matrix passes on 1.24 / stable
- [x] \`go test ./...\` locally on 1.24