### PR TITLE
chore(osfs): announce NewOSFS removal in v0.6.0

### DIFF
--- a/osfs/osfs.go
+++ b/osfs/osfs.go
@@ -59,7 +59,9 @@ var (
 )
 
 // NewOSFS returns a filesystem for the tree of files rooted at the directory dir.
-// Deprecated: Use New.
+//
+// Deprecated: Use New. NewOSFS is retained for backwards compatibility and
+// is scheduled for removal in v0.6.0.
 func NewOSFS(dir string) *OSFS {
 	return New(dir)
 }


### PR DESCRIPTION
## Summary
- \`NewOSFS\` has been Deprecated in favor of \`New\` but with no removal timeline. State explicitly that it will be removed in v0.6.0 so downstream consumers can plan migration.

Part of v0.5.0 release prep. Pure documentation change — no behavior change.

## Test plan
- [x] \`go test ./...\`
- [x] \`staticcheck ./...\`