### PR TITLE
ci: enable -race for go test

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -39,7 +39,7 @@ jobs:
         name: Run go test
         run: |
           go mod tidy
-          go test -v ./...
+          go test -race -v ./...
       -
         # staticcheck v0.7.0 requires Go >= 1.25, so only run linters on
         # the latest toolchain in the matrix. Tests still cover all


### PR DESCRIPTION
## Summary
- Run \`go test\` with \`-race\` in CI. The \`memfs.Sub\` mutex regression fixed in #8 is exactly the kind of bug \`-race\` would have caught on first run.

Part of v0.5.0 release prep.

## Note for reviewers
This PR also touches \`tests.yaml\`, as does #11 (Go matrix). Whichever lands second will need a trivial rebase.

## Test plan
- [x] CI \`go test -race ./...\` passes on all matrix entries
- [x] Local \`go test -race ./...\` passes