### PR TITLE
fix(memfs): Fix enumeration and RemoveAll for prefix-named siblings

### DIFF
--- a/memfs/store.go
+++ b/memfs/store.go
@@ -174,18 +174,28 @@ func (s *store) prefixGlobKeys(prefix, pattern string) ([]string, error) {
 	if i == -1 {
 		return nil, nil
 	}
-	if !strings.HasSuffix(prefix, "/") {
-		prefix = prefix + "/"
+	child := prefix
+	if !strings.HasSuffix(child, "/") {
+		child = child + "/"
 	}
 
 	var keys []string
 	max := len(s.keys)
 	for i++; i < max; i++ {
 		key := s.keys[i]
+		// End of this directory's subtree: once a key no longer shares the
+		// string prefix, no later key can either (s.keys is sorted).
 		if !strings.HasPrefix(key, prefix) {
 			break
 		}
-		ok, err := path.Match(pattern, key[len(prefix):])
+		// A sibling such as "dir0-tmp" shares the string prefix "dir0" but
+		// is not under "dir0/". It can sort between the directory key and
+		// its children (e.g. '-' (0x2d) < '/' (0x2f)), so skip it rather
+		// than stopping the scan.
+		if !strings.HasPrefix(key, child) {
+			continue
+		}
+		ok, err := path.Match(pattern, key[len(child):])
 		if err != nil {
 			return nil, err
 		}

--- a/memfs/store.go
+++ b/memfs/store.go
@@ -140,18 +140,28 @@ func (s *store) prefixKeys(prefix string) []string {
 	if i == -1 {
 		return nil
 	}
-	if !strings.HasSuffix(prefix, "/") {
-		prefix = prefix + "/"
+	child := prefix
+	if !strings.HasSuffix(child, "/") {
+		child = child + "/"
 	}
 
 	var keys []string
 	max := len(s.keys)
 	for i++; i < max; i++ {
 		key := s.keys[i]
+		// End of this directory's subtree: once a key no longer shares the
+		// string prefix, no later key can either (s.keys is sorted).
 		if !strings.HasPrefix(key, prefix) {
 			break
 		}
-		if strings.Contains(key[len(prefix):], "/") {
+		// A sibling such as "dir0-tmp" shares the string prefix "dir0" but
+		// is not under "dir0/". It can sort between the directory key and
+		// its children (e.g. '-' (0x2d) < '/' (0x2f)), so skip it rather
+		// than stopping the scan.
+		if !strings.HasPrefix(key, child) {
+			continue
+		}
+		if strings.Contains(key[len(child):], "/") {
 			continue
 		}
 		keys = append(keys, key)

--- a/memfs/store.go
+++ b/memfs/store.go
@@ -114,17 +114,27 @@ func (s *store) removeAll(prefix string) {
 		return
 	}
 
-	// Find the first key after `from` that does not start with prefix.
-	// Because s.keys is sorted, the prefix-matching range is contiguous,
-	// so we can binary-search for its end instead of scanning.
+	// Find the first key after `from` that does not share the string prefix.
+	// Because s.keys is sorted, that string-prefix range is contiguous, so we
+	// can binary-search for its end instead of scanning.
 	end := sort.Search(len(s.keys)-from, func(i int) bool {
 		return !strings.HasPrefix(s.keys[from+i], prefix)
 	}) + from
 
+	// The range also contains prefix-named siblings such as "dir0-tmp" that
+	// are not under "dir0/". Delete only the directory itself and its true
+	// children (a path-segment match), keeping the siblings intact.
+	child := prefix + "/"
+	kept := make([]string, 0, len(s.keys))
+	kept = append(kept, s.keys[:from]...)
 	for _, key := range s.keys[from:end] {
-		delete(s.values, key)
+		if key == prefix || strings.HasPrefix(key, child) {
+			delete(s.values, key)
+			continue
+		}
+		kept = append(kept, key)
 	}
-	s.keys = append(s.keys[:from], s.keys[end:]...)
+	s.keys = append(kept, s.keys[end:]...)
 }
 
 func (s *store) keyIndex(key string) int {

--- a/memfs/store_test.go
+++ b/memfs/store_test.go
@@ -255,6 +255,58 @@ func TestStore_prefixKeys_siblingPrefix(t *testing.T) {
 	}
 }
 
+func TestStore_prefixGlobKeys_siblingPrefix(t *testing.T) {
+	testCases := []struct {
+		caseName string
+		keys     []string
+		prefix   string
+		pattern  string
+		want     []string
+	}{
+		{
+			caseName: "dash sibling (0x2d < 0x2f)",
+			keys: []string{
+				"/dir0",
+				"/dir0-tmp",
+				"/dir0-tmp/file.txt",
+				"/dir0/file01.txt",
+			},
+			prefix:  "/dir0",
+			pattern: "*.txt",
+			want:    []string{"/dir0/file01.txt"},
+		},
+		{
+			caseName: "underscore sibling (0x5f > 0x2f)",
+			keys: []string{
+				"/dir0",
+				"/dir0/file01.txt",
+				"/dir0_bak",
+				"/dir0_bak/file.txt",
+			},
+			prefix:  "/dir0",
+			pattern: "*.txt",
+			want:    []string{"/dir0/file01.txt"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			s := newStore()
+			for _, k := range tc.keys {
+				s.put(k, &value{name: k, mode: fs.ModePerm})
+			}
+			got, err := s.prefixGlobKeys(tc.prefix, tc.pattern)
+			if err != nil {
+				t.Fatalf(`prefixGlobKeys(%q, %q) error: %v`, tc.prefix, tc.pattern, err)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf(`prefixGlobKeys(%q, %q) got %v; want %v`,
+					tc.prefix, tc.pattern, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestStore_prefixGlobKeys(t *testing.T) {
 	testCases := []struct {
 		want    []string

--- a/memfs/store_test.go
+++ b/memfs/store_test.go
@@ -198,6 +198,63 @@ func TestStore_prefixKeys(t *testing.T) {
 	}
 }
 
+func TestStore_prefixKeys_siblingPrefix(t *testing.T) {
+	testCases := []struct {
+		caseName string
+		keys     []string
+		prefix   string
+		want     []string
+	}{
+		{
+			// '-' (0x2d) < '/' (0x2f): the sibling sorts between the dir
+			// key and its child, tripping the premature break.
+			caseName: "dash sibling (0x2d < 0x2f)",
+			keys: []string{
+				"/dir0",
+				"/dir0-tmp",
+				"/dir0-tmp/file.txt",
+				"/dir0/file01.txt",
+			},
+			prefix: "/dir0",
+			want:   []string{"/dir0/file01.txt"},
+		},
+		{
+			// '_' (0x5f) > '/': the sibling sorts after the child (control).
+			caseName: "underscore sibling (0x5f > 0x2f)",
+			keys: []string{
+				"/dir0",
+				"/dir0/file01.txt",
+				"/dir0_bak",
+				"/dir0_bak/file.txt",
+			},
+			prefix: "/dir0",
+			want:   []string{"/dir0/file01.txt"},
+		},
+		{
+			caseName: "no sibling",
+			keys: []string{
+				"/dir0",
+				"/dir0/file01.txt",
+			},
+			prefix: "/dir0",
+			want:   []string{"/dir0/file01.txt"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.caseName, func(t *testing.T) {
+			s := newStore()
+			for _, k := range tc.keys {
+				s.put(k, &value{name: k, mode: fs.ModePerm})
+			}
+			got := s.prefixKeys(tc.prefix)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf(`prefixKeys(%q) got %v; want %v`, tc.prefix, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestStore_prefixGlobKeys(t *testing.T) {
 	testCases := []struct {
 		want    []string

--- a/memfs/store_test.go
+++ b/memfs/store_test.go
@@ -165,6 +165,34 @@ func TestStore_removeAll(t *testing.T) {
 	}
 }
 
+func TestStore_removeAll_siblingPrefix(t *testing.T) {
+	// removeAll("/dir0") must delete the directory and its real children
+	// only, leaving prefix-named siblings ("/dir0-tmp", "/dir0_bak") intact.
+	// A string-prefix match over-deletes them.
+	s := newStore()
+	keys := []string{
+		"/dir0",
+		"/dir0/file01.txt",
+		"/dir0-tmp",
+		"/dir0-tmp/file.txt",
+		"/dir0_bak",
+	}
+	for _, k := range keys {
+		s.put(k, &value{name: k, mode: fs.ModePerm})
+	}
+
+	s.removeAll("/dir0")
+
+	want := []string{
+		"/dir0-tmp",
+		"/dir0-tmp/file.txt",
+		"/dir0_bak",
+	}
+	if !reflect.DeepEqual(s.keys, want) {
+		t.Errorf(`after removeAll("/dir0") keys = %v; want %v`, s.keys, want)
+	}
+}
+
 func TestStore_prefixKeys(t *testing.T) {
 	testCases := []struct {
 		want   []string


### PR DESCRIPTION
## Summary

In `memfs`, a directory's entries could vanish from enumeration, and `RemoveAll` could delete unrelated directories, when a *sibling* shares the target's name as a string prefix (e.g. `dir0-tmp` alongside `dir0`). All three bugs stem from confusing a *string* prefix with a *path-segment* prefix in `memfs/store.go`. `Open`/`Stat`/`ReadFile` of an exact path were unaffected — only enumeration and bulk removal.

- `prefixKeys` (backs `ReadDir`, and therefore `fs.WalkDir`): broke the scan at the first key not under `dir/`. A sibling like `dir0-tmp` sorts between `dir0` and `dir0/...` (`'-'` 0x2d < `'/'` 0x2f), so the real children were never reached and `ReadDir` returned zero entries. Siblings are now skipped (`continue`); the scan stops only when the shared string prefix ends.
- `prefixGlobKeys` (backs `Glob`): same shape, same fix.
- `removeAll` (backs `RemoveAll`): deleted every key with the string prefix, so `RemoveAll("dir0")` also removed `dir0-tmp`, `dir0_bak`, etc. It now deletes only the directory itself and its true children (`key == prefix || HasPrefix(key, prefix+"/")`).

Surfaced via a downstream backend layered on `wfs` that uses `fs.WalkDir`/`ReadDir`: sibling index directories made a base directory invisible to enumeration under `mem://`, while `osfs` and `s3` behaved correctly (they walk real directories / list a flat keyspace without the contiguity shortcut).

## Test plan

- [x] `go test -race ./...`
- [x] `staticcheck ./memfs/`
- [x] `gosec ./memfs/`
- [x] New table-driven tests reproduce each bug (dash sibling fails before the fix; underscore / no-sibling controls pass)
