### PR TITLE
chore: Modernize interface{} to any and b.N to b.Loop()

### DIFF
--- a/fsdelegator.go
+++ b/fsdelegator.go
@@ -347,7 +347,7 @@ type FileInfoValues struct {
 	Mode    fs.FileMode
 	ModTime time.Time
 	IsDir   bool
-	Sys     interface{}
+	Sys     any
 }
 
 // FileInfoDelegator implements fs.FileInfo.
@@ -383,7 +383,7 @@ func (d *FileInfoDelegator) IsDir() bool {
 }
 
 // Sys returns d.Values.Sys.
-func (d *FileInfoDelegator) Sys() interface{} {
+func (d *FileInfoDelegator) Sys() any {
 	return d.Values.Sys
 }
 

--- a/memfs/store.go
+++ b/memfs/store.go
@@ -46,7 +46,7 @@ func (v *value) IsDir() bool {
 	return v.isDir
 }
 
-func (v *value) Sys() interface{} {
+func (v *value) Sys() any {
 	return nil
 }
 

--- a/memfs/store_test.go
+++ b/memfs/store_test.go
@@ -131,8 +131,7 @@ func BenchmarkStore_put(b *testing.B) {
 		keys[i] = fmt.Sprintf("/dir%05d/file%05d.txt", rng.Intn(n), i)
 	}
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		s := newStore()
 		for _, k := range keys {
 			s.put(k, &value{name: k, mode: fs.ModePerm})


### PR DESCRIPTION
## Summary

Mechanical modernization surfaced by gopls; no behavior change.

- Replace empty `interface{}` with `any` in `FileInfoValues.Sys`, `FileInfoDelegator.Sys()`, and memfs `value.Sys()`.
- Rewrite `BenchmarkStore_put` to use `for b.Loop()` (Go 1.24+), dropping the now-redundant `b.ResetTimer()`.

## Test plan

- [x] `go test -race ./...`
- [x] `go test -bench BenchmarkStore_put` runs
- [x] `staticcheck ./...`
- [x] `gosec ./...`
