### PR TITLE
test(memfs): Avoid reflect.DeepEqual on errors in Remove error tests

### DIFF
--- a/memfs/memfs_test.go
+++ b/memfs/memfs_test.go
@@ -434,11 +434,17 @@ func TestRemoveFile_Errors(t *testing.T) {
 	fsys := newMemFSTest(t)
 	name := "../invalid"
 
-	want := &fs.PathError{Op: "RemoveFile", Path: name, Err: fs.ErrInvalid}
-	got := fsys.RemoveFile(name)
-
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf(`Error RemoveFile("%s") returns %v; want %v`, name, got, want)
+	wantErr := &fs.PathError{Op: "RemoveFile", Path: name, Err: fs.ErrInvalid}
+	err := fsys.RemoveFile(name)
+	if err == nil {
+		t.Fatal("no error")
+	}
+	gotErr, ok := err.(*fs.PathError)
+	if !ok {
+		t.Fatalf("unexpected %v", err)
+	}
+	if gotErr.Error() != wantErr.Error() {
+		t.Errorf(`Error RemoveFile("%s") returns %v; want %v`, name, gotErr, wantErr)
 	}
 }
 
@@ -468,11 +474,17 @@ func TestRemoveAll_Errors(t *testing.T) {
 	fsys := newMemFSTest(t)
 	name := "../invalid"
 
-	want := &fs.PathError{Op: "RemoveAll", Path: name, Err: fs.ErrInvalid}
-	got := fsys.RemoveAll(name)
-
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf(`Error RemoveAll("%s") returns %v; want %v`, name, got, want)
+	wantErr := &fs.PathError{Op: "RemoveAll", Path: name, Err: fs.ErrInvalid}
+	err := fsys.RemoveAll(name)
+	if err == nil {
+		t.Fatal("no error")
+	}
+	gotErr, ok := err.(*fs.PathError)
+	if !ok {
+		t.Fatalf("unexpected %v", err)
+	}
+	if gotErr.Error() != wantErr.Error() {
+		t.Errorf(`Error RemoveAll("%s") returns %v; want %v`, name, gotErr, wantErr)
 	}
 }
 


### PR DESCRIPTION
## Summary

`gopls` flags `reflect.DeepEqual` on error values (`deepequalerrors`). Rewrite the two `RemoveFile`/`RemoveAll` invalid-path tests to the idiom already used in `fs_test.go`: type-assert to `*fs.PathError` and compare `.Error()` strings. Behavior of the assertions is unchanged (Op, Path, and wrapped error are all reflected in the message).

## Test plan

- [x] `go test -race ./...`
- [x] `staticcheck ./...`
- [x] `gosec ./...`
- [x] `gopls check` no longer reports `deepequalerrors`
