### PR TITLE
test(memfs): Use range over int in the Sub concurrency smoke test

### DIFF
--- a/memfs/memfs_test.go
+++ b/memfs/memfs_test.go
@@ -73,12 +73,12 @@ func TestSubSharesMutex(t *testing.T) {
 	// mutex this is race-free; -race will catch a regression.
 	done := make(chan struct{})
 	go func() {
-		for i := 0; i < 100; i++ {
+		for range 100 {
 			_, _ = wfs.WriteFile(fsys, "sub/a.txt", []byte("a"), fs.ModePerm)
 		}
 		close(done)
 	}()
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		_, _ = wfs.WriteFile(sub, "b.txt", []byte("b"), fs.ModePerm)
 	}
 	<-done


### PR DESCRIPTION
## Summary

Address the remaining `rangeint` modernize hint from gopls. Both counter loops in `TestSubSharesMutex` use the loop variable only as a counter, so they convert cleanly to `for range 100` (Go 1.22+). No behavior change.

## Test plan

- [x] `go test -race ./...`
- [x] `staticcheck ./...`
- [x] No `rangeint` candidates remain in the repo
